### PR TITLE
Plug9 Fix

### DIFF
--- a/bond-api/src/main/java/com/abiquo/bond/api/OutboundAPIClient.java
+++ b/bond-api/src/main/java/com/abiquo/bond/api/OutboundAPIClient.java
@@ -246,7 +246,8 @@ public class OutboundAPIClient implements CommsHandler, EventStoreHandler
             new EventTranslator(config.getMServer(),
                 config.getMUser(),
                 config.getMUserPassword(),
-                currUserEditLink);
+                currUserEditLink,
+                mapNameToVMLinks);
 
         for (BackupPluginInterface plugin : handlersWithResponses)
         {


### PR DESCRIPTION
Found two possible reasons for this bug and have fixed both of them
1. The method I was using to cache the VMs only returned VMs in the same enterprise as the user. I have changed this to cache VMs from all enterprises.
2. Newly created VMs were not be added to the cache. New Vms are now added to the cache and undeployed VMs are removed.
