### PR TITLE
Missed a use case when handling defined hour configurations

### DIFF
--- a/bond-api/src/main/java/com/abiquo/bond/api/event/BackupEventConfiguration.java
+++ b/bond-api/src/main/java/com/abiquo/bond/api/event/BackupEventConfiguration.java
@@ -131,9 +131,45 @@ public class BackupEventConfiguration
         }
     }
 
-    public boolean isConfigured()
+    public boolean isConfigured(final EnumSet<VMBackupConfiguration> acceptable)
     {
-        return hourly != null || daily != null || weekly_planned != null || monthly != null;
+        for (VMBackupConfiguration cfg : acceptable)
+        {
+            switch (cfg)
+            {
+                case DEFINED_HOUR:
+                    if (definedhour != null)
+                    {
+                        return true;
+                    }
+                    break;
+                case HOURLY:
+                    if (hourly != null)
+                    {
+                        return true;
+                    }
+                    break;
+                case DAILY:
+                    if (daily != null)
+                    {
+                        return true;
+                    }
+                    break;
+                case WEEKLY:
+                    if (weekly_planned != null)
+                    {
+                        return true;
+                    }
+                    break;
+                case MONTHLY:
+                    if (monthly != null)
+                    {
+                        return true;
+                    }
+                    break;
+            }
+        }
+        return false;
     }
 
     public Optional<Date> getDefinedHourDateAndTime()

--- a/bond-api/src/main/java/com/abiquo/bond/api/event/VirtualMachineEvent.java
+++ b/bond-api/src/main/java/com/abiquo/bond/api/event/VirtualMachineEvent.java
@@ -199,31 +199,33 @@ public class VirtualMachineEvent extends APIEvent
 
     public boolean backupIsConfigured()
     {
-        return backupIsConfigured(EnumSet.allOf(VMBackupType.class));
+        return backupIsConfigured(EnumSet.allOf(VMBackupType.class),
+            EnumSet.allOf(VMBackupConfiguration.class));
     }
 
-    public boolean backupIsConfigured(final EnumSet<VMBackupType> acceptable)
+    public boolean backupIsConfigured(final EnumSet<VMBackupType> acceptableTypes,
+        final EnumSet<VMBackupConfiguration> acceptableConfigurations)
     {
         if (backupIsConfigured)
         {
-            for (VMBackupType bt : acceptable)
+            for (VMBackupType bt : acceptableTypes)
             {
                 switch (bt)
                 {
                     case COMPLETE:
-                        if (bcComplete.isConfigured())
+                        if (bcComplete.isConfigured(acceptableConfigurations))
                         {
                             return true;
                         }
                         break;
                     case FILESYSTEM:
-                        if (bcFileSystem.isConfigured())
+                        if (bcFileSystem.isConfigured(acceptableConfigurations))
                         {
                             return true;
                         }
                         break;
                     case SNAPSHOT:
-                        if (bcSnapshot.isConfigured())
+                        if (bcSnapshot.isConfigured(acceptableConfigurations))
                         {
                             return true;
                         }


### PR DESCRIPTION
Previous defined hour fix handled the case where the defined hour was the only configuration.
However if another configuration was set as well, then two jobs were being created where the one job (based on the defined hour configuration) had no schedule set.
Jobs are now only created based on configurations that the VEEAM server supports - any other configuration is simply ignored.
